### PR TITLE
Add analytics events during checkout funnel

### DIFF
--- a/packages/core/src/app/billing/Billing.tsx
+++ b/packages/core/src/app/billing/Billing.tsx
@@ -14,6 +14,7 @@ import getBillingMethodId from './getBillingMethodId';
 import BillingForm, { BillingFormValues } from './BillingForm';
 
 export interface BillingProps {
+    emitAnalyticsEvent(event: string): void;
     navigateNextStep(): void;
     onReady?(): void;
     onUnhandledError(error: Error): void;
@@ -92,7 +93,10 @@ class Billing extends Component<BillingProps & WithCheckoutBillingProps> {
             billingAddress,
             navigateNextStep,
             onUnhandledError,
+            emitAnalyticsEvent,
         } = this.props;
+
+        emitAnalyticsEvent("Billing details entered");
 
         const promises: Array<Promise<CheckoutSelectors>> = [];
         const address = mapAddressFromFormValues(addressValues);

--- a/packages/core/src/app/checkout/AnalyticsEvents.ts
+++ b/packages/core/src/app/checkout/AnalyticsEvents.ts
@@ -11,21 +11,26 @@ export const AnalyticsEvents = {
     if(window && window.BoltTrack) {
       boltTracker = window.BoltTrack
       console.log("--bolt bigc--: successfully assigned window BoltTrack")
-      // immediately send checkout start event
+      // immediately send checkout load success event
       AnalyticsEvents.emitEvent("Checkout load success")
     }
   },
   emitEvent: (eventName: string) => {
     console.log("--bolt bigc--: emitting analytics event ", eventName);
     const props: any = {
-      nextState: eventName
+      nextState: eventName,
+      prevState: ""
     }
     if (eventLog.length > 0) {
       props.prevState = eventLog[0];
     }
-    boltTracker.recordEvent("CheckoutFunnelTransition", props)
-    eventLog.unshift(eventName)
-    console.log("--bolt bigc--: successfully sent analytics event ", eventName);
+    try {
+      boltTracker.recordEvent("CheckoutFunnelTransition", props)
+      // add latest event to beginning of log array
+      eventLog.unshift(eventName)
+    } catch (e) {
+      console.log("--bolt bigc--: error during emitting event ", e)
+    }
   },
   onBeforeUnload: () => {
     AnalyticsEvents.emitEvent("Exit")

--- a/packages/core/src/app/checkout/AnalyticsEvents.ts
+++ b/packages/core/src/app/checkout/AnalyticsEvents.ts
@@ -1,0 +1,32 @@
+
+let boltTracker: Window["BoltTrack"] = {
+  recordEvent: (event: string) => console.log("--bolt bigc--: NOOP ", event)
+}
+
+const eventLog: string[] = []
+
+export const AnalyticsEvents = {
+  init: () => {
+    console.log("--bolt bigc--: intializing Bolt-BigC analytics events")
+    if(window && window.BoltTrack) {
+      boltTracker = window.BoltTrack
+      console.log("--bolt bigc--: successfully assigned window BoltTrack")
+      // immediately send checkout start event
+      AnalyticsEvents.emitEvent("Checkout load success")
+    }
+  },
+  emitEvent: (eventName: string) => {
+    console.log("--bolt bigc--: emitting analytics event ", eventName);
+    if (boltTracker.recordEvent) {
+      const props: any = {
+        nextState: eventName
+      }
+      if (eventLog.length > 0) {
+        props.prevState = eventLog[0];
+      }
+      boltTracker.recordEvent("CheckoutFunnelTransition", props)
+      eventLog.push(eventName)
+      console.log("--bolt bigc--: successfully sent analytics event ", eventName);
+    }
+  }
+}

--- a/packages/core/src/app/checkout/AnalyticsEvents.ts
+++ b/packages/core/src/app/checkout/AnalyticsEvents.ts
@@ -17,16 +17,17 @@ export const AnalyticsEvents = {
   },
   emitEvent: (eventName: string) => {
     console.log("--bolt bigc--: emitting analytics event ", eventName);
-    if (boltTracker.recordEvent) {
-      const props: any = {
-        nextState: eventName
-      }
-      if (eventLog.length > 0) {
-        props.prevState = eventLog[0];
-      }
-      boltTracker.recordEvent("CheckoutFunnelTransition", props)
-      eventLog.push(eventName)
-      console.log("--bolt bigc--: successfully sent analytics event ", eventName);
+    const props: any = {
+      nextState: eventName
     }
+    if (eventLog.length > 0) {
+      props.prevState = eventLog[0];
+    }
+    boltTracker.recordEvent("CheckoutFunnelTransition", props)
+    eventLog.unshift(eventName)
+    console.log("--bolt bigc--: successfully sent analytics event ", eventName);
+  },
+  onBeforeUnload: () => {
+    AnalyticsEvents.emitEvent("Exit")
   }
 }

--- a/packages/core/src/app/customer/Customer.tsx
+++ b/packages/core/src/app/customer/Customer.tsx
@@ -26,6 +26,7 @@ export interface CustomerProps {
     onSignIn?(): void;
     onSignInError?(error: Error): void;
     onUnhandledError?(error: Error): void;
+    emitAnalyticsEvent(event: string): void;
 }
 
 export interface WithCheckoutCustomerProps {
@@ -66,6 +67,7 @@ export interface CustomerState {
     isEmailLoginFormOpen: boolean;
     isReady: boolean;
     hasRequestedLoginEmail: boolean;
+    hasInputEmail: boolean;
 }
 
 class Customer extends Component<CustomerProps & WithCheckoutCustomerProps, CustomerState> {
@@ -73,6 +75,7 @@ class Customer extends Component<CustomerProps & WithCheckoutCustomerProps, Cust
         isEmailLoginFormOpen: false,
         isReady: false,
         hasRequestedLoginEmail: false,
+        hasInputEmail: false,
     };
 
     private draftEmail?: string;
@@ -405,6 +408,12 @@ class Customer extends Component<CustomerProps & WithCheckoutCustomerProps, Cust
     };
 
     private handleChangeEmail: (email: string) => void = email => {
+        const { hasInputEmail } = this.state;
+        const { emitAnalyticsEvent } = this.props;
+        if (!hasInputEmail) {
+            emitAnalyticsEvent("Detail entry began");
+            this.setState({ hasInputEmail: true });
+        }
         this.draftEmail = email;
     };
 
@@ -419,9 +428,11 @@ class Customer extends Component<CustomerProps & WithCheckoutCustomerProps, Cust
             executePaymentMethodCheckout,
             onContinueAsGuest = noop,
             providerWithCustomCheckout,
+            emitAnalyticsEvent,
         } = this.props;
 
         if (providerWithCustomCheckout) {
+            emitAnalyticsEvent("Account recognition");
             await executePaymentMethodCheckout({ methodId: providerWithCustomCheckout, continueWithCheckoutCallback: onContinueAsGuest });
         } else {
             onContinueAsGuest();

--- a/packages/core/src/app/payment/Payment.tsx
+++ b/packages/core/src/app/payment/Payment.tsx
@@ -21,6 +21,7 @@ export interface PaymentProps {
     isEmbedded?: boolean;
     isUsingMultiShipping?: boolean;
     checkEmbeddedSupport?(methodIds: string[]): void; // TODO: We're currently doing this check in multiple places, perhaps we should move it up so this check get be done in a single place instead.
+    emitAnalyticsEvent(event: string): void;
     onCartChangedError?(error: CartChangedError): void;
     onFinalize?(): void;
     onFinalizeError?(error: Error): void;
@@ -380,6 +381,7 @@ class Payment extends Component<PaymentProps & WithCheckoutPaymentProps & WithLa
             onSubmit = noop,
             onSubmitError = noop,
             submitOrder,
+            emitAnalyticsEvent,
         } = this.props;
 
         const {
@@ -400,6 +402,7 @@ class Payment extends Component<PaymentProps & WithCheckoutPaymentProps & WithLa
             const order = state.data.getOrder();
             onSubmit(order?.orderId);
         } catch (error) {
+            emitAnalyticsEvent("Payment rejected");
             if (error.type === 'payment_method_invalid') {
                 return loadPaymentMethods();
             }

--- a/packages/core/src/app/shipping/Shipping.tsx
+++ b/packages/core/src/app/shipping/Shipping.tsx
@@ -25,6 +25,7 @@ export interface ShippingProps {
     onReady?(): void;
     onUnhandledError(error: Error): void;
     onSignIn(): void;
+    emitAnalyticsEvent(event: string): void;
     navigateNextStep(isBillingSameAsShipping: boolean): void;
 }
 
@@ -108,6 +109,7 @@ class Shipping extends Component<ShippingProps & WithCheckoutShippingProps, Ship
             deinitializeShippingMethod,
             isMultiShippingMode,
             onToggleMultiShipping,
+            emitAnalyticsEvent,
             ...shippingFormProps
         } = this.props;
 
@@ -132,6 +134,7 @@ class Shipping extends Component<ShippingProps & WithCheckoutShippingProps, Ship
                         { ...shippingFormProps }
                         addresses={ customer.addresses }
                         deinitialize={ deinitializeShippingMethod }
+                        emitAnalyticsEvent={ emitAnalyticsEvent }
                         initialize={ initializeShippingMethod }
                         isBillingSameAsShipping = { isBillingSameAsShipping }
                         isGuest={ isGuest }
@@ -187,11 +190,17 @@ class Shipping extends Component<ShippingProps & WithCheckoutShippingProps, Ship
             shippingAddress,
             billingAddress,
             methodId,
+            emitAnalyticsEvent,
         } = this.props;
 
         const updatedShippingAddress = addressValues && mapAddressFromFormValues(addressValues);
         const promises: Array<Promise<CheckoutSelectors>> = [];
         const hasRemoteBilling = this.hasRemoteBilling(methodId);
+
+        emitAnalyticsEvent("Shipping method step complete");
+        if (billingSameAsShipping) {
+            emitAnalyticsEvent("Billing details entered")
+        }
 
         if (!isEqualAddress(updatedShippingAddress, shippingAddress)) {
             promises.push(updateShippingAddress(updatedShippingAddress || {}));

--- a/packages/core/src/app/shipping/ShippingForm.tsx
+++ b/packages/core/src/app/shipping/ShippingForm.tsx
@@ -33,6 +33,7 @@ export interface ShippingFormProps {
     onCreateAccount(): void;
     createCustomerAddress(address: AddressRequestBody): Promise<CheckoutSelectors>;
     onMultiShippingSubmit(values: MultiShippingFormValues): void;
+    emitAnalyticsEvent(event: string): void;
     onSignIn(): void;
     onSingleShippingSubmit(values: SingleShippingFormValues): void;
     onUnhandledError(error: Error): void;
@@ -76,6 +77,7 @@ class ShippingForm extends Component<ShippingFormProps & WithLanguageProps> {
             signOut,
             updateAddress,
             isShippingStepPending,
+            emitAnalyticsEvent,
         } = this.props;
 
         return isMultiShippingMode ?
@@ -111,6 +113,7 @@ class ShippingForm extends Component<ShippingFormProps & WithLanguageProps> {
                 customerMessage={ customerMessage }
                 deinitialize={ deinitialize }
                 deleteConsignments={ deleteConsignments }
+                emitAnalyticsEvent={ emitAnalyticsEvent }
                 getFields={ getFields }
                 googleMapsApiKey={ googleMapsApiKey }
                 initialize={ initialize }

--- a/packages/core/types/window.d.ts
+++ b/packages/core/types/window.d.ts
@@ -1,0 +1,9 @@
+export {};
+
+declare global {
+  interface Window {
+    BoltTrack: { 
+      recordEvent: (event: string, properties?: any) => void;
+    }
+  }
+}


### PR DESCRIPTION
## What?
Add analytics events emitting during guest checkout funnel via Track.js on `window.BoltTrack.recordEvent()`.
[Events](https://docs.google.com/spreadsheets/d/11BNt3pSiQZq34zXMOfojOIs7RjbVm-mD8QA0s255viE/edit#gid=0) added so far:
* Checkout load success
* Detail entry began
* Account recognition
* Shipping details fully entered
* Shipping method step complete
* Billing details entered
* Payment details fully entered
* Payment complete
* Payment rejected
* Exit

Next steps: emitting events when details are autocompleted (e.g.: info saved in localstorage between checkout sessions or when exiting the bolt modal)

## Why?
...

## Testing / Proof
So far have verified that logs have been sent to the logging endpoint for each individual step 
