### PR TITLE
Emit events on detail autocomplete

### DIFF
--- a/packages/core/src/app/checkout/Checkout.tsx
+++ b/packages/core/src/app/checkout/Checkout.tsx
@@ -204,8 +204,10 @@ class Checkout extends Component<CheckoutProps & WithCheckoutProps & WithLanguag
         }
     }
 
-    private emitAnalyticsEvent(event: string): void {
-        // 
+    private emitAnalyticsEvent: (event:string) => void = (event: string) => {
+        // when events are emitted by manually entering details on each step,
+        // set a stepComplete state flag so that duplicate events aren't emitted
+        // from the navigateToNextStep function
         switch(event) {
             case "Account recognition":
                 this.setState({ isCustomerEmailComplete: true });

--- a/packages/core/src/app/checkout/Checkout.tsx
+++ b/packages/core/src/app/checkout/Checkout.tsx
@@ -77,6 +77,9 @@ export interface CheckoutState {
     isRedirecting: boolean;
     hasSelectedShippingOptions: boolean;
     isBuyNowCartEnabled: boolean;
+    isCustomerEmailComplete: boolean;
+    isShippingComplete: boolean;
+    isBillingComplete: boolean;
 }
 
 export interface WithCheckoutProps {
@@ -109,6 +112,9 @@ class Checkout extends Component<CheckoutProps & WithCheckoutProps & WithLanguag
         isMultiShippingMode: false,
         hasSelectedShippingOptions: false,
         isBuyNowCartEnabled: false,
+        isCustomerEmailComplete: false,
+        isShippingComplete: false,
+        isBillingComplete: false,
     };
 
     private embeddedMessenger?: EmbeddedCheckoutMessenger;
@@ -199,6 +205,18 @@ class Checkout extends Component<CheckoutProps & WithCheckoutProps & WithLanguag
     }
 
     private emitAnalyticsEvent(event: string): void {
+        // 
+        switch(event) {
+            case "Account recognition":
+                this.setState({ isCustomerEmailComplete: true });
+                break;
+            case "Shipping method step complete":
+                this.setState({ isShippingComplete: true });
+                break;
+            case "Billing details entered":
+                this.setState({ isBillingComplete: true });
+                break;
+        }
         AnalyticsEvents.emitEvent(event);
     }
 
@@ -463,7 +481,12 @@ class Checkout extends Component<CheckoutProps & WithCheckoutProps & WithLanguag
 
     private navigateToStep(type: CheckoutStepType, options?: { isDefault?: boolean }): void {
         const { clearError, error, steps } = this.props;
-        const { activeStepType } = this.state;
+        const {
+            activeStepType,
+            isCustomerEmailComplete,
+            isShippingComplete,
+            isBillingComplete
+        } = this.state;
         const step = find(steps, { type });
 
         if (!step) {
@@ -472,6 +495,42 @@ class Checkout extends Component<CheckoutProps & WithCheckoutProps & WithLanguag
 
         if (activeStepType === step.type) {
             return;
+        }
+
+        const nextStepIndex = findIndex(steps, { type })
+        const prevStepIndex = nextStepIndex - 1;
+        const prevStep = prevStepIndex >= 0 && steps[prevStepIndex];
+
+        /**
+         * BOLT ANALYTICS
+         * This block is to handle emitting step completion events when details are autocompleted.
+         * Events will still be emitted from the individual steps and will set completion state flags
+         * so that when this block runs during step transitions, we don't emit duplicate events.
+         */
+        if (prevStep && prevStep.isComplete) {
+            switch(prevStep.type) {
+                case "customer":
+                    if (!isCustomerEmailComplete) {
+                        // if stepping through customer step automatically (saved info) emit all beginning events
+                        this.emitAnalyticsEvent("Detail entry began")
+                        this.emitAnalyticsEvent("Account recognition")
+                    }
+                    break;
+                case "billing":
+                    // for some reason "shipping" is *never* a previous step,
+                    // so checking for shipping status when billing is the previous step
+                    if (!isShippingComplete) {
+                        const shippingStep = (find(steps, { type: "shipping" }) as CheckoutStepStatus)
+                        if (shippingStep && shippingStep.isComplete) {
+                            this.emitAnalyticsEvent("Shipping details fully entered");
+                            this.emitAnalyticsEvent("Shipping method step complete");
+                        }
+                    }
+                    if (!isBillingComplete) {
+                        this.emitAnalyticsEvent("Billing details entered")
+                    }
+                    break;
+            }
         }
 
         if (options && options.isDefault) {

--- a/packages/core/src/app/payment/Payment.tsx
+++ b/packages/core/src/app/payment/Payment.tsx
@@ -389,6 +389,8 @@ class Payment extends Component<PaymentProps & WithCheckoutPaymentProps & WithLa
             submitFunctions,
         } = this.state;
 
+        emitAnalyticsEvent("Payment details fully entered")
+
         const customSubmit = selectedMethod && submitFunctions[
             getUniquePaymentMethodId(selectedMethod.id, selectedMethod.gateway)
         ];


### PR DESCRIPTION
## What?
Add code block within step transitions to emit events only when details are autocompleted. This is represented by "stepComplete" state flags that are set when specific events that mark the completion of a step are emitted.

## Why?
...

## Testing / Proof
Still testing locally...
