### PR TITLE
Add events related to the "bolt button"

### DIFF
--- a/packages/core/src/app/billing/Billing.tsx
+++ b/packages/core/src/app/billing/Billing.tsx
@@ -12,6 +12,7 @@ import { LoadingOverlay } from '../ui/loading';
 
 import getBillingMethodId from './getBillingMethodId';
 import BillingForm, { BillingFormValues } from './BillingForm';
+import { GuestCheckoutEvents } from '../checkout/AnalyticsEvents';
 
 export interface BillingProps {
     emitAnalyticsEvent(event: string): void;
@@ -96,7 +97,7 @@ class Billing extends Component<BillingProps & WithCheckoutBillingProps> {
             emitAnalyticsEvent,
         } = this.props;
 
-        emitAnalyticsEvent("Billing details entered");
+        emitAnalyticsEvent(GuestCheckoutEvents.BillingEntered);
 
         const promises: Array<Promise<CheckoutSelectors>> = [];
         const address = mapAddressFromFormValues(addressValues);

--- a/packages/core/src/app/checkout/AnalyticsEvents.d.ts
+++ b/packages/core/src/app/checkout/AnalyticsEvents.d.ts
@@ -1,0 +1,19 @@
+export declare enum GuestCheckoutEvents {
+    CheckoutLoadSuccess = "Checkout load success",
+    DetailEntryBegan = "Detail entry began",
+    AccountButtonClick = "Account lookup button click",
+    BoltButtonExists = "Bolt recognized button rendered",
+    BoltButtonClicked = "Bolt recognized button clicked",
+    ShippingEntered = "Shipping details fully entered",
+    ShippingComplete = "Shipping method step complete",
+    BillingEntered = "Billing details entered",
+    PaymentEntered = "Payment details entered",
+    PaymentRejected = "Payment rejected",
+    PaymentSuccessful = "Payment successful",
+    Exit = "Exit"
+}
+export declare const AnalyticsEvents: {
+    init: () => void;
+    emitEvent: (eventName: string) => void;
+    onBeforeUnload: () => void;
+};

--- a/packages/core/src/app/checkout/AnalyticsEvents.ts
+++ b/packages/core/src/app/checkout/AnalyticsEvents.ts
@@ -4,6 +4,21 @@ let boltTracker: Window["BoltTrack"] = {
 
 const eventLog: string[] = [];
 
+export enum GuestCheckoutEvents {
+  CheckoutLoadSuccess = "Checkout load success",
+  DetailEntryBegan = "Detail entry began",
+  AccountButtonClick = "Account lookup button click",
+  BoltButtonExists = "Bolt recognized button rendered",
+  BoltButtonClicked = "Bolt recognized button clicked",
+  ShippingEntered = "Shipping details fully entered",
+  ShippingComplete = "Shipping method step complete",
+  BillingEntered = "Billing details entered",
+  PaymentEntered = "Payment details entered",
+  PaymentRejected = "Payment rejected",
+  PaymentSuccessful = "Payment successful",
+  Exit = "Exit"
+}
+
 export const AnalyticsEvents = {
   init: () => {
     try {

--- a/packages/core/src/app/checkout/Checkout.tsx
+++ b/packages/core/src/app/checkout/Checkout.tsx
@@ -210,10 +210,6 @@ class Checkout extends Component<CheckoutProps & WithCheckoutProps & WithLanguag
         }
     }
 
-    private handleBoltCheckoutButtonRendered: () => void = () => {
-        this.setState({ isBoltCheckoutButtonRendered: true })
-    }
-
     private emitAnalyticsEvent: (event:string) => void = (event: string) => {
         // when events are emitted by manually entering details on each step,
         // set a stepComplete state flag so that duplicate events aren't emitted
@@ -344,7 +340,7 @@ class Checkout extends Component<CheckoutProps & WithCheckoutProps & WithLanguag
                 key={ step.type }
                 onEdit={ this.handleEditStep }
                 onExpanded={ this.handleExpanded }
-                suggestion={ <CheckoutSuggestion emitAnalyticsEvent={ this.emitAnalyticsEvent } onBoltRendered={ this.handleBoltCheckoutButtonRendered }/> }
+                suggestion={ <CheckoutSuggestion emitAnalyticsEvent={ this.emitAnalyticsEvent } /> }
                 summary={
                     <CustomerInfo
                         onSignOut={ this.handleSignOut }
@@ -409,10 +405,10 @@ class Checkout extends Component<CheckoutProps & WithCheckoutProps & WithLanguag
                 <LazyContainer>
                     <Shipping
                         cartHasChanged={ hasCartChanged }
-                        isShippingDetailsEntered={ isShippingDetailsEntered }
                         emitAnalyticsEvent={ this.emitAnalyticsEvent }
                         isBillingSameAsShipping={ isBillingSameAsShipping }
                         isMultiShippingMode={ isMultiShippingMode }
+                        isShippingDetailsEntered={ isShippingDetailsEntered }
                         navigateNextStep={ this.handleShippingNextStep }
                         onCreateAccount={ this.handleShippingCreateAccount }
                         onReady={ this.handleReady }
@@ -544,11 +540,7 @@ class Checkout extends Component<CheckoutProps & WithCheckoutProps & WithLanguag
                     }
                     if (!isCustomerEmailComplete) {
                         // if stepping through customer step automatically (saved info) emit all beginning events
-                        this.emitAnalyticsEvent(GuestCheckoutEvents.AccountButtonClick)    
-                        // if the blue Bolt Checkout button is visible, send "Bolt checkout button exists"
-                        if (isBoltCheckoutButtonRendered) {
-                            this.emitAnalyticsEvent(GuestCheckoutEvents.BoltButtonExists)
-                        }
+                        this.emitAnalyticsEvent(GuestCheckoutEvents.AccountButtonClick)
                     }
                     break;
                 case "billing":

--- a/packages/core/src/app/checkout/Checkout.tsx
+++ b/packages/core/src/app/checkout/Checkout.tsx
@@ -80,6 +80,7 @@ export interface CheckoutState {
     hasDetailEntryBegan: boolean;
     isCustomerEmailComplete: boolean;
     isBoltCheckoutButtonRendered: boolean;
+    isShippingDetailsEntered: boolean;
     isShippingComplete: boolean;
     isBillingComplete: boolean;
 }
@@ -117,6 +118,7 @@ class Checkout extends Component<CheckoutProps & WithCheckoutProps & WithLanguag
         hasDetailEntryBegan: false,
         isCustomerEmailComplete: false,
         isBoltCheckoutButtonRendered: false,
+        isShippingDetailsEntered: false,
         isShippingComplete: false,
         isBillingComplete: false,
     };
@@ -222,6 +224,9 @@ class Checkout extends Component<CheckoutProps & WithCheckoutProps & WithLanguag
                 break;
             case GuestCheckoutEvents.AccountButtonClick:
                 this.setState({ isCustomerEmailComplete: true });
+                break;
+            case GuestCheckoutEvents.ShippingEntered:
+                this.setState({ isShippingDetailsEntered: true });
                 break;
             case GuestCheckoutEvents.ShippingComplete:
                 this.setState({ isShippingComplete: true });
@@ -378,6 +383,7 @@ class Checkout extends Component<CheckoutProps & WithCheckoutProps & WithLanguag
         const {
             isBillingSameAsShipping,
             isMultiShippingMode,
+            isShippingDetailsEntered,
         } = this.state;
 
         if (!cart) {
@@ -403,6 +409,7 @@ class Checkout extends Component<CheckoutProps & WithCheckoutProps & WithLanguag
                 <LazyContainer>
                     <Shipping
                         cartHasChanged={ hasCartChanged }
+                        isShippingDetailsEntered={ isShippingDetailsEntered }
                         emitAnalyticsEvent={ this.emitAnalyticsEvent }
                         isBillingSameAsShipping={ isBillingSameAsShipping }
                         isMultiShippingMode={ isMultiShippingMode }

--- a/packages/core/src/app/customer/Customer.tsx
+++ b/packages/core/src/app/customer/Customer.tsx
@@ -27,6 +27,7 @@ export interface CustomerProps {
     onSignInError?(error: Error): void;
     onUnhandledError?(error: Error): void;
     emitAnalyticsEvent(event: string): void;
+    hasDetailEntryBegan: boolean;
 }
 
 export interface WithCheckoutCustomerProps {
@@ -67,7 +68,6 @@ export interface CustomerState {
     isEmailLoginFormOpen: boolean;
     isReady: boolean;
     hasRequestedLoginEmail: boolean;
-    hasInputEmail: boolean;
 }
 
 class Customer extends Component<CustomerProps & WithCheckoutCustomerProps, CustomerState> {
@@ -75,7 +75,6 @@ class Customer extends Component<CustomerProps & WithCheckoutCustomerProps, Cust
         isEmailLoginFormOpen: false,
         isReady: false,
         hasRequestedLoginEmail: false,
-        hasInputEmail: false,
     };
 
     private draftEmail?: string;
@@ -408,11 +407,9 @@ class Customer extends Component<CustomerProps & WithCheckoutCustomerProps, Cust
     };
 
     private handleChangeEmail: (email: string) => void = email => {
-        const { hasInputEmail } = this.state;
-        const { emitAnalyticsEvent } = this.props;
-        if (!hasInputEmail) {
+        const { emitAnalyticsEvent, hasDetailEntryBegan } = this.props;
+        if (!hasDetailEntryBegan) {
             emitAnalyticsEvent("Detail entry began");
-            this.setState({ hasInputEmail: true });
         }
         this.draftEmail = email;
     };

--- a/packages/core/src/app/customer/Customer.tsx
+++ b/packages/core/src/app/customer/Customer.tsx
@@ -13,6 +13,7 @@ import CustomerViewType from './CustomerViewType';
 import EmailLoginForm, { EmailLoginFormValues } from './EmailLoginForm';
 import GuestForm, { GuestFormValues } from './GuestForm';
 import LoginForm from './LoginForm';
+import { GuestCheckoutEvents } from '../checkout/AnalyticsEvents';
 
 export interface CustomerProps {
     viewType: CustomerViewType;
@@ -409,7 +410,7 @@ class Customer extends Component<CustomerProps & WithCheckoutCustomerProps, Cust
     private handleChangeEmail: (email: string) => void = email => {
         const { emitAnalyticsEvent, hasDetailEntryBegan } = this.props;
         if (!hasDetailEntryBegan) {
-            emitAnalyticsEvent("Detail entry began");
+            emitAnalyticsEvent(GuestCheckoutEvents.DetailEntryBegan);
         }
         this.draftEmail = email;
     };
@@ -429,7 +430,7 @@ class Customer extends Component<CustomerProps & WithCheckoutCustomerProps, Cust
         } = this.props;
 
         if (providerWithCustomCheckout) {
-            emitAnalyticsEvent("Account lookup button click");
+            emitAnalyticsEvent(GuestCheckoutEvents.AccountButtonClick);
             await executePaymentMethodCheckout({ methodId: providerWithCustomCheckout, continueWithCheckoutCallback: onContinueAsGuest });
         } else {
             onContinueAsGuest();

--- a/packages/core/src/app/customer/checkoutSuggestion/BoltCheckoutSuggestion.tsx
+++ b/packages/core/src/app/customer/checkoutSuggestion/BoltCheckoutSuggestion.tsx
@@ -1,6 +1,7 @@
 import { CheckoutSelectors, CustomerInitializeOptions, CustomerRequestOptions, ExecutePaymentMethodCheckoutOptions } from '@bigcommerce/checkout-sdk';
 import { noop } from 'lodash';
 import React, { memo, useEffect, useState, FunctionComponent } from 'react';
+import { GuestCheckoutEvents } from '../../checkout/AnalyticsEvents';
 
 import { stopPropagation } from '../../common/dom';
 import { TranslatedString } from '../../locale';
@@ -54,7 +55,7 @@ const BoltCheckoutSuggestion: FunctionComponent<BoltCheckoutSuggestionProps> = (
     }
 
     const handleActionClick = async () => {
-        emitAnalyticsEvent("Bolt checkout button clicked");
+        emitAnalyticsEvent(GuestCheckoutEvents.BoltButtonClicked);
         await executePaymentMethodCheckout({ methodId });
     };
 

--- a/packages/core/src/app/customer/checkoutSuggestion/BoltCheckoutSuggestion.tsx
+++ b/packages/core/src/app/customer/checkoutSuggestion/BoltCheckoutSuggestion.tsx
@@ -14,6 +14,7 @@ export interface BoltCheckoutSuggestionProps {
     executePaymentMethodCheckout(options: ExecutePaymentMethodCheckoutOptions): Promise<CheckoutSelectors>;
     initializeCustomer(options: CustomerInitializeOptions): Promise<CheckoutSelectors>;
     onUnhandledError?(error: Error): void;
+    emitAnalyticsEvent(event: string): void;
 }
 
 const BoltCheckoutSuggestion: FunctionComponent<BoltCheckoutSuggestionProps> = ({
@@ -23,6 +24,7 @@ const BoltCheckoutSuggestion: FunctionComponent<BoltCheckoutSuggestionProps> = (
     executePaymentMethodCheckout,
     initializeCustomer,
     onUnhandledError = noop,
+    emitAnalyticsEvent,
 }) => {
     const [ showSuggestion, setShowSuggestion ] = useState<boolean>(false);
 
@@ -52,6 +54,7 @@ const BoltCheckoutSuggestion: FunctionComponent<BoltCheckoutSuggestionProps> = (
     }
 
     const handleActionClick = async () => {
+        emitAnalyticsEvent("Bolt checkout button clicked");
         await executePaymentMethodCheckout({ methodId });
     };
 

--- a/packages/core/src/app/customer/checkoutSuggestion/BoltCheckoutSuggestion.tsx
+++ b/packages/core/src/app/customer/checkoutSuggestion/BoltCheckoutSuggestion.tsx
@@ -37,6 +37,9 @@ const BoltCheckoutSuggestion: FunctionComponent<BoltCheckoutSuggestionProps> = (
                 methodId,
                 bolt: {
                     onInit: hasBoltAccount => {
+                        if (hasBoltAccount) {
+                            emitAnalyticsEvent(GuestCheckoutEvents.BoltButtonExists);
+                        }
                         setShowSuggestion(hasBoltAccount);
                     },
                 },

--- a/packages/core/src/app/customer/checkoutSuggestion/CheckoutSuggestion.tsx
+++ b/packages/core/src/app/customer/checkoutSuggestion/CheckoutSuggestion.tsx
@@ -1,5 +1,5 @@
 import { CheckoutSelectors, CustomerInitializeOptions, CustomerRequestOptions, ExecutePaymentMethodCheckoutOptions } from '@bigcommerce/checkout-sdk';
-import React, { memo, FunctionComponent, useEffect } from 'react';
+import React, { memo, FunctionComponent } from 'react';
 
 import { withCheckout, CheckoutContextProps } from '../../checkout';
 import { PaymentMethodId } from '../../payment/paymentMethod';
@@ -8,7 +8,6 @@ import BoltCheckoutSuggestion from './BoltCheckoutSuggestion';
 
 export interface CheckoutSuggestionProps {
     onUnhandledError?(error: Error): void;
-    onBoltRendered(): void;
     emitAnalyticsEvent(event: string): void;
 }
 
@@ -22,15 +21,8 @@ export interface WithCheckoutSuggestionsProps {
 
 const CheckoutSuggestion: FunctionComponent<WithCheckoutSuggestionsProps & CheckoutSuggestionProps> = ({
    providerWithCustomCheckout,
-   onBoltRendered,
    ...rest
 }) => {
-    useEffect(() => {
-        if(providerWithCustomCheckout === PaymentMethodId.Bolt) {
-            onBoltRendered();
-        }
-    }, [providerWithCustomCheckout, onBoltRendered]);
-
     if (providerWithCustomCheckout === PaymentMethodId.Bolt) {
         return <BoltCheckoutSuggestion methodId={ providerWithCustomCheckout } { ...rest } />;
     }

--- a/packages/core/src/app/customer/checkoutSuggestion/CheckoutSuggestion.tsx
+++ b/packages/core/src/app/customer/checkoutSuggestion/CheckoutSuggestion.tsx
@@ -1,5 +1,5 @@
 import { CheckoutSelectors, CustomerInitializeOptions, CustomerRequestOptions, ExecutePaymentMethodCheckoutOptions } from '@bigcommerce/checkout-sdk';
-import React, { memo, FunctionComponent } from 'react';
+import React, { memo, FunctionComponent, useEffect } from 'react';
 
 import { withCheckout, CheckoutContextProps } from '../../checkout';
 import { PaymentMethodId } from '../../payment/paymentMethod';
@@ -8,6 +8,8 @@ import BoltCheckoutSuggestion from './BoltCheckoutSuggestion';
 
 export interface CheckoutSuggestionProps {
     onUnhandledError?(error: Error): void;
+    onBoltRendered(): void;
+    emitAnalyticsEvent(event: string): void;
 }
 
 export interface WithCheckoutSuggestionsProps {
@@ -20,8 +22,15 @@ export interface WithCheckoutSuggestionsProps {
 
 const CheckoutSuggestion: FunctionComponent<WithCheckoutSuggestionsProps & CheckoutSuggestionProps> = ({
    providerWithCustomCheckout,
+   onBoltRendered,
    ...rest
 }) => {
+    useEffect(() => {
+        if(providerWithCustomCheckout === PaymentMethodId.Bolt) {
+            onBoltRendered();
+        }
+    }, [providerWithCustomCheckout, onBoltRendered]);
+
     if (providerWithCustomCheckout === PaymentMethodId.Bolt) {
         return <BoltCheckoutSuggestion methodId={ providerWithCustomCheckout } { ...rest } />;
     }

--- a/packages/core/src/app/payment/Payment.tsx
+++ b/packages/core/src/app/payment/Payment.tsx
@@ -16,6 +16,7 @@ import mapToOrderRequestBody from './mapToOrderRequestBody';
 import { getUniquePaymentMethodId, PaymentMethodId, PaymentMethodProviderType } from './paymentMethod';
 import PaymentContext from './PaymentContext';
 import PaymentForm, { PaymentFormValues } from './PaymentForm';
+import { GuestCheckoutEvents } from '../checkout/AnalyticsEvents';
 
 export interface PaymentProps {
     isEmbedded?: boolean;
@@ -389,7 +390,7 @@ class Payment extends Component<PaymentProps & WithCheckoutPaymentProps & WithLa
             submitFunctions,
         } = this.state;
 
-        emitAnalyticsEvent("Payment details fully entered")
+        emitAnalyticsEvent(GuestCheckoutEvents.PaymentEntered)
 
         const customSubmit = selectedMethod && submitFunctions[
             getUniquePaymentMethodId(selectedMethod.id, selectedMethod.gateway)
@@ -404,7 +405,7 @@ class Payment extends Component<PaymentProps & WithCheckoutPaymentProps & WithLa
             const order = state.data.getOrder();
             onSubmit(order?.orderId);
         } catch (error) {
-            emitAnalyticsEvent("Payment rejected");
+            emitAnalyticsEvent(GuestCheckoutEvents.PaymentRejected);
             if (error.type === 'payment_method_invalid') {
                 return loadPaymentMethods();
             }

--- a/packages/core/src/app/shipping/Shipping.tsx
+++ b/packages/core/src/app/shipping/Shipping.tsx
@@ -5,6 +5,7 @@ import { createSelector } from 'reselect';
 
 import { isEqualAddress, mapAddressFromFormValues } from '../address';
 import { withCheckout, CheckoutContextProps } from '../checkout';
+import { GuestCheckoutEvents } from '../checkout/AnalyticsEvents';
 import { EMPTY_ARRAY } from '../common/utility';
 import { LoadingOverlay } from '../ui/loading';
 
@@ -197,9 +198,9 @@ class Shipping extends Component<ShippingProps & WithCheckoutShippingProps, Ship
         const promises: Array<Promise<CheckoutSelectors>> = [];
         const hasRemoteBilling = this.hasRemoteBilling(methodId);
 
-        emitAnalyticsEvent("Shipping method step complete");
+        emitAnalyticsEvent(GuestCheckoutEvents.ShippingComplete);
         if (billingSameAsShipping) {
-            emitAnalyticsEvent("Billing details entered")
+            emitAnalyticsEvent(GuestCheckoutEvents.BillingEntered);
         }
 
         if (!isEqualAddress(updatedShippingAddress, shippingAddress)) {

--- a/packages/core/src/app/shipping/Shipping.tsx
+++ b/packages/core/src/app/shipping/Shipping.tsx
@@ -21,6 +21,7 @@ export interface ShippingProps {
     isBillingSameAsShipping: boolean;
     cartHasChanged: boolean;
     isMultiShippingMode: boolean;
+    isShippingDetailsEntered: boolean;
     onCreateAccount(): void;
     onToggleMultiShipping(): void;
     onReady?(): void;
@@ -116,6 +117,7 @@ class Shipping extends Component<ShippingProps & WithCheckoutShippingProps, Ship
 
         const {
             isInitializing,
+            isShippingDetailsEntered,
         } = this.state;
 
         return (
@@ -192,12 +194,15 @@ class Shipping extends Component<ShippingProps & WithCheckoutShippingProps, Ship
             billingAddress,
             methodId,
             emitAnalyticsEvent,
+            isShippingDetailsEntered,
         } = this.props;
 
         const updatedShippingAddress = addressValues && mapAddressFromFormValues(addressValues);
         const promises: Array<Promise<CheckoutSelectors>> = [];
         const hasRemoteBilling = this.hasRemoteBilling(methodId);
-
+        if (!isShippingDetailsEntered) {
+            emitAnalyticsEvent(GuestCheckoutEvents.ShippingEntered);
+        }
         emitAnalyticsEvent(GuestCheckoutEvents.ShippingComplete);
         if (billingSameAsShipping) {
             emitAnalyticsEvent(GuestCheckoutEvents.BillingEntered);

--- a/packages/core/src/app/shipping/Shipping.tsx
+++ b/packages/core/src/app/shipping/Shipping.tsx
@@ -117,7 +117,6 @@ class Shipping extends Component<ShippingProps & WithCheckoutShippingProps, Ship
 
         const {
             isInitializing,
-            isShippingDetailsEntered,
         } = this.state;
 
         return (

--- a/packages/core/src/app/shipping/SingleShippingForm.tsx
+++ b/packages/core/src/app/shipping/SingleShippingForm.tsx
@@ -14,6 +14,7 @@ import BillingSameAsShippingField from './BillingSameAsShippingField';
 import ShippingAddress from './ShippingAddress';
 import { SHIPPING_ADDRESS_FIELDS } from './ShippingAddressFields';
 import ShippingFormFooter from './ShippingFormFooter';
+import { GuestCheckoutEvents } from '../checkout/AnalyticsEvents';
 
 export interface SingleShippingFormProps {
     addresses: CustomerAddress[];
@@ -88,7 +89,7 @@ class SingleShippingForm extends PureComponent<SingleShippingFormProps & WithLan
                 });
                 if (includeShippingOptions) {
                     if (!this.state.hasLoadedShippingOptions) {
-                        emitAnalyticsEvent("Shipping details fully entered");
+                        emitAnalyticsEvent(GuestCheckoutEvents.ShippingEntered);
                         this.setState({ hasLoadedShippingOptions: true });
                     }
                     this.setState({ hasRequestedShippingOptions: true });


### PR DESCRIPTION
## What?
Main addition is adding the following events:
* "Bolt checkout button exists" -> emitted when Bolt checkout button is visible at checkout start when email is prefilled and shopper has bolt account
* "Bolt checkout button clicked" -> emitted when Bolt checkout button is clicked

Changes include:
* moving event names to a single enum
* emit "shipping details fully entered" in [scenario k](https://whimsical.com/bc-embedded-data-funnel-379J9Ta8TZqLWwEPEssU1Y) where shipping address is auto filled and shopper clicks "continue"
* fine tuning event emitting during step transitions

## Why?
...

## Testing / Proof
Confirmed all events are being sent as expected