### PR TITLE
Fix incorrect event name "Payment complete"

### DIFF
--- a/packages/core/src/app/checkout/AnalyticsEvents.d.ts
+++ b/packages/core/src/app/checkout/AnalyticsEvents.d.ts
@@ -2,6 +2,7 @@ export declare enum GuestCheckoutEvents {
     CheckoutLoadSuccess = "Checkout load success",
     DetailEntryBegan = "Detail entry began",
     AccountButtonClick = "Account lookup button click",
+    AccountLookupSkipped = "Account lookup skipped",
     BoltButtonExists = "Bolt recognized button rendered",
     BoltButtonClicked = "Bolt recognized button clicked",
     ShippingEntered = "Shipping details fully entered",
@@ -9,7 +10,7 @@ export declare enum GuestCheckoutEvents {
     BillingEntered = "Billing details entered",
     PaymentEntered = "Payment details entered",
     PaymentRejected = "Payment rejected",
-    PaymentSuccessful = "Payment successful",
+    PaymentComplete = "Payment complete",
     Exit = "Exit"
 }
 export declare const AnalyticsEvents: {

--- a/packages/core/src/app/checkout/AnalyticsEvents.ts
+++ b/packages/core/src/app/checkout/AnalyticsEvents.ts
@@ -16,7 +16,7 @@ export enum GuestCheckoutEvents {
   BillingEntered = "Billing details entered",
   PaymentEntered = "Payment details entered",
   PaymentRejected = "Payment rejected",
-  PaymentSuccessful = "Payment successful",
+  PaymentComplete = "Payment complete",
   Exit = "Exit"
 }
 

--- a/packages/core/src/app/checkout/Checkout.tsx
+++ b/packages/core/src/app/checkout/Checkout.tsx
@@ -605,7 +605,7 @@ class Checkout extends Component<CheckoutProps & WithCheckoutProps & WithLanguag
         const { steps } = this.props;
         const { isBuyNowCartEnabled } = this.state;
 
-        this.emitAnalyticsEvent(GuestCheckoutEvents.PaymentSuccessful)
+        this.emitAnalyticsEvent(GuestCheckoutEvents.PaymentComplete)
 
         if (this.stepTracker) {
             this.stepTracker.trackStepCompleted(steps[steps.length - 1].type);


### PR DESCRIPTION
## What?
Fix event name for "Payment complete" introduced [here](https://github.com/owenchak/checkout-js/pull/9/files#diff-35032bbdd731d9be48678a1cfe49d965a1a00bca923660714421ce5b9b89ebf6R601).

## Why?
...

## Testing / Proof
...
