### PR TITLE
Switch analytics event emitting to use BoltAnalytics

### DIFF
--- a/packages/core/src/app/checkout/AnalyticsEvents.ts
+++ b/packages/core/src/app/checkout/AnalyticsEvents.ts
@@ -1,8 +1,6 @@
-let boltTracker: Window["BoltTrack"] = {
-  recordEvent: (event: string) => console.log("--bolt bigc--: NOOP ", event),
-};
+let boltTracker: Window["BoltAnalytics"] = {};
 
-const eventLog: string[] = [];
+const eventQueue: any[] = [];
 
 export enum GuestCheckoutEvents {
   CheckoutLoadSuccess = "Checkout load success",
@@ -21,34 +19,79 @@ export enum GuestCheckoutEvents {
   Exit = "Exit"
 }
 
+const defaultTimeout = 1000;
+const defaultPollingInterval = 10;
+// borrowed polling mechanism 
+async function pollUntilAccepted<T>(
+  fn: () => T,
+  accept: (t: T) => boolean,
+  timeoutMillis = defaultTimeout,
+  interval = defaultPollingInterval,
+): Promise<T | Error> {
+  return new Promise<T | Error>(resolve => {
+    let remainingTime = timeoutMillis;
+
+    const intervalId = setInterval(() => {
+      if (remainingTime < 0) {
+        clearInterval(intervalId);
+        resolve(new Error(`Timed out while waiting for ${fn} (${timeoutMillis}ms)`));
+        return;
+      }
+
+      const value = fn();
+      if (accept(value)) {
+        const timeElapsed = timeoutMillis - remainingTime;
+        console.log(`--bolt bigc--: poll condition accepted after ${timeElapsed} ms`);
+        clearInterval(intervalId);
+        resolve(value);
+        return;
+      }
+
+      remainingTime = remainingTime - interval;
+    }, interval);
+  });
+}
+
+function checkForBoltAnalytics() {
+  try {
+    if (window && window.BoltAnalytics) {
+      boltTracker = window.BoltAnalytics;
+      console.log("--bolt bigc--: successfully found window.BoltAnalytics");
+      return true;
+    }
+  } catch (e) {
+    console.log("--bolt bigc--: error while initializing AnalyticsEvents", e);
+  }
+  return false;
+}
+
 export const AnalyticsEvents = {
   init: () => {
     try {
-      console.log("--bolt bigc--: intializing Bolt-BigC analytics events");
-      if (window && window.BoltTrack) {
-        boltTracker = window.BoltTrack;
-        console.log("--bolt bigc--: successfully assigned window BoltTrack");
-        // immediately send checkout load success event
-        AnalyticsEvents.emitEvent("Checkout load success");
-      }
+      // immediately send checkout load success event
+      AnalyticsEvents.emitEvent("Checkout load success");
+      // poll until window.BoltAnalytics is on the page
+      pollUntilAccepted(checkForBoltAnalytics, t => t, 3000)
+        .catch(e => console.warn("--bolt bigc--: failure to locate BoltAnalytics on the window", e));
     } catch (e) {
-      console.log("--bolt bigc--: error during emitting event ", e);
+      console.log("--bolt bigc--: error during polling for BoltAnalytics", e);
     }
   },
   emitEvent: (eventName: string, eventProps?: any) => {
     try {
-      console.log("--bolt bigc--: emitting analytics event ", eventName);
-      const props: any = {
-        ...eventProps,
-        nextState: eventName,
-        prevState: "",
-      };
-      if (eventLog.length > 0) {
-        props.prevState = eventLog[0];
+      eventQueue.push({ eventName, eventProps });
+      // wait until checkoutStepComplete is defined to emit logs
+      if (!boltTracker || !boltTracker.checkoutStepComplete) {
+        return;
       }
-      boltTracker.recordEvent("CheckoutFunnelTransition", props);
-      // add latest event to beginning of log array
-      eventLog.unshift(eventName);
+
+      while (eventQueue.length) {
+        const { eventName, eventProps } = eventQueue.shift();
+
+        console.log("--bolt bigc--: emitting analytics event ", eventName);
+
+        boltTracker.checkoutStepComplete(eventName, eventProps);
+      }
     } catch (e) {
       console.log("--bolt bigc--: error during emitting event ", e);
     }

--- a/packages/core/src/app/checkout/AnalyticsEvents.ts
+++ b/packages/core/src/app/checkout/AnalyticsEvents.ts
@@ -22,7 +22,7 @@ export enum GuestCheckoutEvents {
 const defaultTimeout = 1000;
 const defaultPollingInterval = 10;
 // borrowed polling mechanism 
-async function pollUntilAccepted<T>(
+function pollUntilAccepted<T>(
   fn: () => T,
   accept: (t: T) => boolean,
   timeoutMillis = defaultTimeout,

--- a/packages/core/types/window.d.ts
+++ b/packages/core/types/window.d.ts
@@ -2,8 +2,8 @@ export {};
 
 declare global {
   interface Window {
-    BoltTrack: { 
-      recordEvent: (event: string, properties?: any) => void;
+    BoltAnalytics: {
+      checkoutStepComplete?: (event: string, properties?: any) => void;
     }
   }
 }


### PR DESCRIPTION
## What?
Switching event emitting to connect after update gets merged to production (eta tuesday next week).

Since the connect script arrives later on the DOM than track.js does _and_ because it's appended to the DOM manually by BigC's checkout code, dom ready events ("DOMContentLoaded", "onLoad", etc...) do not help to check when `window.BoltAnalytics` is defined. 

Thus, I've added a polling mechanism with event queuing to check for when connect assigns `BoltAnalytics` on the window. On the following event emit call, the queued events get sent to the log endpoint.

## Why?
This will be the supported interface for Cart Platforms to use long-term. So we want to test with LAPG to make sure we have the instrumentation set up right on the Bolt side.

## Testing / Proof
So far this works with both full guest checkout and device-saved account info flows and I'm planning on testing with Yunlu at the start of next week before rolling out to LAPG.
